### PR TITLE
Fixed an issue with candle initialization

### DIFF
--- a/candle/__init__.py
+++ b/candle/__init__.py
@@ -93,6 +93,11 @@ try:
 except ImportError:
     pass
 
+try:
+    import torch
+except ImportError:
+    pass
+
 if "tensorflow" in sys.modules:
     print("Importing candle utils for keras")
 


### PR DESCRIPTION
In an environment where only PyTorch is installed importing 'candle' module prior to 'torch' resulted in "No backend has been specified." exception.  Adding try/catch statement loading 'torch' module (analogous to the one for tensorflow) fixes an issue.