### PR TITLE
DRAFT: datadir and creation of directories in CDD

### DIFF
--- a/candle/file_utils.py
+++ b/candle/file_utils.py
@@ -44,8 +44,8 @@ def get_file(
     if cache_subdir is not None:
         datadir = os.path.join(datadir, cache_subdir)
 
-    if not os.path.exists(datadir):
-        os.makedirs(datadir)
+    # if not os.path.exists(datadir):
+    #     os.makedirs(datadir)
 
     if fname.endswith(".tar.gz"):
         fnamesplit = fname.split(".tar.gz")

--- a/candle/file_utils.py
+++ b/candle/file_utils.py
@@ -63,8 +63,10 @@ def get_file(
         unpack_fpath = None
 
     fpath = os.path.join(datadir, fname)
-    if not os.path.exists(os.path.dirname(fpath)):
-        os.makedirs(os.path.dirname(fpath))
+    print("fpath = ", fpath)
+    print("datadir = ", datadir)
+    # if not os.path.exists(os.path.dirname(fpath)):
+    #     os.makedirs(os.path.dirname(fpath))
 
     download = False
     if os.path.exists(fpath) or (

--- a/candle/file_utils.py
+++ b/candle/file_utils.py
@@ -191,8 +191,10 @@ def directory_tree_from_parameters(
 
     # Construct data directory trees recursively without
     # complaining if they exist
-    if not os.path.exists(datadir):
-        os.makedirs(datadir, exist_ok=True)
+    # TODO: Understand why this is commented out and why it is needed?
+    # This breaks when we don't have access to the data directory
+    # if not os.path.exists(datadir):
+    #     os.makedirs(datadir, exist_ok=True)
 
     # Output directory tree part
     # First part can be:


### PR DESCRIPTION
For `CANDLE_MODEL_TYPE ` `BENCHMARKS ` we should never create dirs or touch anything in CDD (CANDLE_DATA_DIR).
For `CANDLE_MODEL_TYPE` `SINGULARITY ` we can create these directories and store results.

More work needed to guard these two cases.

See build 225 and 226 here: https://jenkins-gce.cels.anl.gov/job/CANDLE-WF-mlrMBO-NT3/ 

This is context for adapting things for the [IMPROVE](https://github.com/JDACS4C-IMPROVE/) project.

Where is datadirs used? Is it only for IMPROVE or was it used for ECP-CANDLE/Benchmarks?